### PR TITLE
Provide an error when requestToken did not return a body

### DIFF
--- a/lib/fuel-auth.js
+++ b/lib/fuel-auth.js
@@ -164,12 +164,21 @@ FuelAuth.prototype._requestToken = function(requestOptions) {
 
 	return new Promise(function(resolve, reject) {
 		request(options, function (err, res, body) {
+			var localError;
+
 			if(err) {
 				return reject(err);
 			}
 
+			if(!body) {
+				localError     = new Error('No response body');
+				localError.res = res;
+				reject(localError);
+				return;
+			}
+
 			// setting variables on object created to be used later
-			if(body && body.refreshToken) {
+			if(body.refreshToken) {
 				this.refreshToken = body.refreshToken;
 			}
 

--- a/test/_requestToken.js
+++ b/test/_requestToken.js
@@ -81,6 +81,19 @@ describe('_requestToken', function() {
 			});
 	});
 
+	it('should fail if request successful without body', function () {
+		nock('http://127.0.0.1:3000')
+			.post('/v1/requestToken')
+			.reply(200);
+
+		return AuthClient
+			._requestToken()
+			.then(
+				function onResolve() { assert(false, 'Unexpected resolve'); },
+				function onReject(err) { assert.equal(err.message, 'No response body'); }
+			);
+	});
+
 	it('should add refreshToken to json if set on client', function(done) {
 		var refreshToken = '<refreshToken>';
 		var calledWithRefreshToken = false;


### PR DESCRIPTION
This resolves an issue where the call to requestToken does not error, but there was some communication breakdown that resulted in no body and an unhandled exception was thrown from an async context.

/cc @vernak2539 @nathan-boyd 