### PR TITLE
Add coverage directory to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ test
 testing.js
 *.tgz
 node_modules
+coverage


### PR DESCRIPTION
This adds the coverage directory created by istanbul to the ignores for npm. The most recent package, 2.0.1, was published with the coverage directory, which bloats the size of the on-disk install and leaks file system information from the author's computer.